### PR TITLE
Add DuckDuckGo FIlter

### DIFF
--- a/resources/script.js
+++ b/resources/script.js
@@ -37,6 +37,12 @@ function authification(url, href, origin, hostname,protocol,pathname)
 		return `<h3> This page is part of your browser<h3>`;
 	}
 	else if(protocol != "https:" ) {return `<h3> This website is not secure. Please refrain from submitting personal data and don't download files from such sources</h3>`;}
+	
+	else if(origin=="https://duckduckgo.com")
+		{ if(pathname=="/") return `<p> This is DuckDuckGo Search Engine Result page. Be wary of the links you click from a results page.</p>`;
+		  else{ link=hostname; var output = compare(link); return output;}
+		}
+	
 	else if( origin =="https://www.facebook.com" )  
 			{	
 				link= hostname+'/'+pathname.split('/')[1];


### PR DESCRIPTION
If the URL is DDG search result page, it shows that it is a search result page. If the URL is anything else then the regular compare with links in the dB.

fixes #17