### PR TITLE
Add bing search filter

### DIFF
--- a/resources/script.js
+++ b/resources/script.js
@@ -42,6 +42,10 @@ function authification(url, href, origin, hostname,protocol,pathname)
 		{ if(pathname=="/") return `<p> This is DuckDuckGo Search Engine Result page. Be wary of the links you click from a results page.</p>`;
 		  else{ link=hostname; var output = compare(link); return output;}
 		}
+	else if(origin=="https://www.bing.com") 
+		{ if(pathname=="/search" || pathname=="/shop") { return `<p> This is Microsoft Bing Search Engine Result page. Be wary of the links you click from a results page.</p>`;}
+		else{ link=hostname; var output = compare(link); return output;}
+		}	
 	
 	else if( origin =="https://www.facebook.com" )  
 			{	


### PR DESCRIPTION
Fixes #18
URL's of bing search page results are added as a filter. Only General search and shopping page search results are added, 